### PR TITLE
fix: restore i18n integration for invoice components

### DIFF
--- a/src/components/invoice/InvoiceForm.tsx
+++ b/src/components/invoice/InvoiceForm.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { Invoice, LineItem, InvoiceTemplate } from "@/lib/types";
-import { X, RotateCcw, Copy } from "lucide-react";
+import { Invoice, LineItem } from "@/lib/types";
+import { X, RotateCcw } from "lucide-react";
+import { useI18n } from '@/i18n/context';
 import ImageUpload from "@/components/ui/ImageUpload";
 
 interface InvoiceFormProps {
@@ -11,7 +12,6 @@ interface InvoiceFormProps {
   onAddLineItem: () => void;
   onRemoveLineItem: (index: number) => void;
   onLoadDemoData: () => void;
-  onApplyTemplate?: (template: InvoiceTemplate) => void;
 }
 
 export default function InvoiceForm({
@@ -21,56 +21,57 @@ export default function InvoiceForm({
   onAddLineItem,
   onRemoveLineItem,
   onLoadDemoData,
-  onApplyTemplate,
 }: InvoiceFormProps) {
+  const { tInvoice } = useI18n();
+
   return (
     <div className="space-y-6">
       {/* Invoice Header */}
       <div className="bg-white rounded-lg shadow-sm p-6">
         <h2 className="text-lg font-medium text-slate-900 mb-4">
-          Invoice Details
+          {tInvoice('invoice.details.header') || 'Invoice Details'}
         </h2>
         <div className="grid grid-cols-2 gap-4">
           <div>
             <label className="block text-sm font-medium text-slate-700 mb-1">
-              Invoice Number *
+              {tInvoice('invoice.details.number') || 'Invoice Number'} *
             </label>
             <input
               type="text"
               value={invoice.number}
               onChange={(e) => onUpdate({ number: e.target.value })}
               className="w-full px-3 py-2 border border-slate-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
-              placeholder="INV-001"
-              aria-label="Invoice Number"
+              placeholder={tInvoice('invoice.details.numberPlaceholder') || 'INV-001'}
+              aria-label={tInvoice('invoice.details.number') || 'Invoice Number'}
             />
           </div>
           <div>
             <label className="block text-sm font-medium text-slate-700 mb-1">
-              Date *
+              {tInvoice('invoice.details.date') || 'Date'} *
             </label>
             <input
               type="date"
               value={invoice.date}
               onChange={(e) => onUpdate({ date: e.target.value })}
               className="w-full px-3 py-2 border border-slate-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
-              aria-label="Date"
+              aria-label={tInvoice('invoice.details.date') || 'Date'}
             />
           </div>
           <div>
             <label className="block text-sm font-medium text-slate-700 mb-1">
-              Due Date
+              {tInvoice('invoice.details.dueDate') || 'Due Date'}
             </label>
             <input
               type="date"
               value={invoice.dueDate}
               onChange={(e) => onUpdate({ dueDate: e.target.value })}
               className="w-full px-3 py-2 border border-slate-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
-              aria-label="Due Date"
+              aria-label={tInvoice('invoice.details.dueDate') || 'Due Date'}
             />
           </div>
           <div>
             <label className="block text-sm font-medium text-slate-700 mb-1">
-              Tax Rate (%)
+              {tInvoice('invoice.details.taxRate') || 'Tax Rate (%)'}
             </label>
             <input
               type="number"
@@ -82,7 +83,7 @@ export default function InvoiceForm({
               step="0.1"
               min="0"
               max="100"
-              aria-label="Tax Rate"
+              aria-label={tInvoice('invoice.details.taxRate') || 'Tax Rate'}
             />
           </div>
         </div>
@@ -91,11 +92,11 @@ export default function InvoiceForm({
       {/* Design Section with Logo */}
       <div className="bg-white rounded-lg shadow-sm p-6">
         <h2 className="text-lg font-medium text-slate-900 mb-4">
-          Design Elements
+          {tInvoice('invoice.design.header') || 'Design Elements'}
         </h2>
         <div className="grid grid-cols-1 md:grid-cols-1 gap-6">
           <ImageUpload
-            label="Company Logo"
+            label={tInvoice('invoice.design.logoLabel') || 'Company Logo'}
             value={invoice.logoUrl}
             onChange={(logoUrl) => onUpdate({ logoUrl })}
           />
@@ -105,7 +106,7 @@ export default function InvoiceForm({
       {/* From Section */}
       <div className="bg-white rounded-lg shadow-sm p-6">
         <h2 className="text-lg font-medium text-slate-900 mb-4">
-          From (Your Business)
+          {tInvoice('invoice.from.header') || 'From (Your Business)'}
         </h2>
         <div className="space-y-3">
           <input
@@ -117,8 +118,8 @@ export default function InvoiceForm({
               })
             }
             className="w-full px-3 py-2 border border-slate-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
-            placeholder="Business Name *"
-            aria-label="Business Name"
+            placeholder={tInvoice('invoice.from.businessNamePlaceholder') || 'Business Name *'}
+            aria-label={tInvoice('invoice.from.businessName') || 'Business Name'}
           />
           <input
             type="text"
@@ -127,8 +128,8 @@ export default function InvoiceForm({
               onUpdate({ from: { ...invoice.from, address: e.target.value } })
             }
             className="w-full px-3 py-2 border border-slate-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
-            placeholder="Street Address"
-            aria-label="From Address"
+            placeholder={tInvoice('invoice.from.addressPlaceholder') || 'Street Address'}
+            aria-label={tInvoice('invoice.from.address') || 'From Address'}
           />
           <div className="grid grid-cols-2 gap-3">
             <input
@@ -140,8 +141,8 @@ export default function InvoiceForm({
                 })
               }
               className="px-3 py-2 border border-slate-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
-              placeholder="City, State, ZIP"
-              aria-label="From City, State, ZIP"
+              placeholder={tInvoice('invoice.from.locationPlaceholder') || 'City, State, ZIP'}
+              aria-label={tInvoice('invoice.from.location') || 'From City, State, ZIP'}
             />
             <input
               type="text"
@@ -150,8 +151,8 @@ export default function InvoiceForm({
                 onUpdate({ from: { ...invoice.from, country: e.target.value } })
               }
               className="px-3 py-2 border border-slate-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
-              placeholder="Country"
-              aria-label="From Country"
+              placeholder={tInvoice('invoice.from.countryPlaceholder') || 'Country'}
+              aria-label={tInvoice('invoice.from.country') || 'From Country'}
             />
           </div>
           <div className="grid grid-cols-2 gap-3">
@@ -162,8 +163,8 @@ export default function InvoiceForm({
                 onUpdate({ from: { ...invoice.from, email: e.target.value } })
               }
               className="px-3 py-2 border border-slate-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
-              placeholder="Email *"
-              aria-label="From Email"
+              placeholder={tInvoice('invoice.from.emailPlaceholder') || 'Email *'}
+              aria-label={tInvoice('invoice.from.email') || 'From Email'}
             />
             <input
               type="tel"
@@ -172,8 +173,8 @@ export default function InvoiceForm({
                 onUpdate({ from: { ...invoice.from, phone: e.target.value } })
               }
               className="px-3 py-2 border border-slate-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
-              placeholder="Phone"
-              aria-label="From Phone"
+              placeholder={tInvoice('invoice.from.phonePlaceholder') || 'Phone'}
+              aria-label={tInvoice('invoice.from.phone') || 'From Phone'}
             />
           </div>
         </div>
@@ -181,7 +182,7 @@ export default function InvoiceForm({
 
       {/* To Section */}
       <div className="bg-white rounded-lg shadow-sm p-6">
-        <h2 className="text-lg font-medium text-slate-900 mb-4">To (Client)</h2>
+        <h2 className="text-lg font-medium text-slate-900 mb-4">{tInvoice('invoice.to.header') || 'To (Client)'}</h2>
         <div className="space-y-3">
           <input
             type="text"
@@ -190,8 +191,8 @@ export default function InvoiceForm({
               onUpdate({ to: { ...invoice.to, clientName: e.target.value } })
             }
             className="w-full px-3 py-2 border border-slate-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
-            placeholder="Client Name *"
-            aria-label="Client Name"
+            placeholder={tInvoice('invoice.to.clientNamePlaceholder') || 'Client Name *'}
+            aria-label={tInvoice('invoice.to.clientName') || 'Client Name'}
           />
           <input
             type="text"
@@ -200,8 +201,8 @@ export default function InvoiceForm({
               onUpdate({ to: { ...invoice.to, company: e.target.value } })
             }
             className="w-full px-3 py-2 border border-slate-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
-            placeholder="Company"
-            aria-label="Client Company"
+            placeholder={tInvoice('invoice.to.companyPlaceholder') || 'Company'}
+            aria-label={tInvoice('invoice.to.company') || 'Client Company'}
           />
           <input
             type="text"
@@ -210,8 +211,8 @@ export default function InvoiceForm({
               onUpdate({ to: { ...invoice.to, address: e.target.value } })
             }
             className="w-full px-3 py-2 border border-slate-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
-            placeholder="Street Address"
-            aria-label="Client Address"
+            placeholder={tInvoice('invoice.to.addressPlaceholder') || 'Street Address'}
+            aria-label={tInvoice('invoice.to.address') || 'Client Address'}
           />
           <div className="grid grid-cols-2 gap-3">
             <input
@@ -223,8 +224,8 @@ export default function InvoiceForm({
                 })
               }
               className="px-3 py-2 border border-slate-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
-              placeholder="City, State, ZIP"
-              aria-label="Client City, State, ZIP"
+              placeholder={tInvoice('invoice.to.locationPlaceholder') || 'City, State, ZIP'}
+              aria-label={tInvoice('invoice.to.location') || 'Client City, State, ZIP'}
             />
             <input
               type="text"
@@ -233,8 +234,8 @@ export default function InvoiceForm({
                 onUpdate({ to: { ...invoice.to, country: e.target.value } })
               }
               className="px-3 py-2 border border-slate-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
-              placeholder="Country"
-              aria-label="Client Country"
+              placeholder={tInvoice('invoice.to.countryPlaceholder') || 'Country'}
+              aria-label={tInvoice('invoice.to.country') || 'Client Country'}
             />
           </div>
           <div className="grid grid-cols-2 gap-3">
@@ -245,8 +246,8 @@ export default function InvoiceForm({
                 onUpdate({ to: { ...invoice.to, email: e.target.value } })
               }
               className="px-3 py-2 border border-slate-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
-              placeholder="Email"
-              aria-label="Client Email"
+              placeholder={tInvoice('invoice.to.emailPlaceholder') || 'Email'}
+              aria-label={tInvoice('invoice.to.email') || 'Client Email'}
             />
             <input
               type="tel"
@@ -255,8 +256,8 @@ export default function InvoiceForm({
                 onUpdate({ to: { ...invoice.to, phone: e.target.value } })
               }
               className="px-3 py-2 border border-slate-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
-              placeholder="Phone"
-              aria-label="Client Phone"
+              placeholder={tInvoice('invoice.to.phonePlaceholder') || 'Phone'}
+              aria-label={tInvoice('invoice.to.phone') || 'Client Phone'}
             />
           </div>
         </div>
@@ -264,7 +265,7 @@ export default function InvoiceForm({
 
       {/* Line Items */}
       <div className="bg-white rounded-lg shadow-sm p-6">
-        <h2 className="text-lg font-medium text-slate-900 mb-4">Line Items</h2>
+        <h2 className="text-lg font-medium text-slate-900 mb-4">{tInvoice('invoice.lineItems.header') || 'Line Items'}</h2>
         <div className="space-y-3">
           {invoice.items.map((item, index) => (
             <div key={index} className="flex gap-3 items-start group">
@@ -275,7 +276,7 @@ export default function InvoiceForm({
                   onLineItemChange(index, { description: e.target.value })
                 }
                 className="flex-1 px-3 py-2 border border-slate-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
-                placeholder="Description"
+                placeholder={tInvoice('invoice.lineItems.descriptionPlaceholder') || 'Description'}
               />
               <input
                 type="number"
@@ -286,7 +287,7 @@ export default function InvoiceForm({
                   })
                 }
                 className="w-20 px-3 py-2 border border-slate-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
-                placeholder="Qty"
+                placeholder={tInvoice('invoice.lineItems.quantityPlaceholder') || 'Qty'}
                 min="0"
               />
               <input
@@ -298,7 +299,7 @@ export default function InvoiceForm({
                   })
                 }
                 className="w-24 px-3 py-2 border border-slate-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
-                placeholder="Rate"
+                placeholder={tInvoice('invoice.lineItems.ratePlaceholder') || 'Rate'}
                 min="0"
                 step="0.01"
               />
@@ -321,7 +322,7 @@ export default function InvoiceForm({
           onClick={onAddLineItem}
           className="mt-4 w-full py-2 border-2 border-dashed border-slate-300 rounded-md text-slate-500 hover:border-primary hover:text-primary transition-colors"
         >
-          + Add Line Item
+          {tInvoice('invoice.lineItems.addButton') || '+ Add Line Item'}
         </button>
       </div>
 
@@ -330,50 +331,40 @@ export default function InvoiceForm({
         <div className="grid grid-cols-2 gap-4">
           <div>
             <label className="block text-sm font-medium text-slate-700 mb-1">
-              Notes
+              {tInvoice('invoice.notes.label') || 'Notes'}
             </label>
             <textarea
               value={invoice.notes}
               onChange={(e) => onUpdate({ notes: e.target.value })}
               rows={3}
               className="w-full px-3 py-2 border border-slate-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent resize-none"
-              placeholder="Thank you for your business!"
+              placeholder={tInvoice('invoice.notes.placeholder') || 'Thank you for your business!'}
             />
           </div>
           <div>
             <label className="block text-sm font-medium text-slate-700 mb-1">
-              Terms
+              {tInvoice('invoice.terms.label') || 'Terms'}
             </label>
             <textarea
               value={invoice.terms}
               onChange={(e) => onUpdate({ terms: e.target.value })}
               rows={3}
               className="w-full px-3 py-2 border border-slate-300 rounded-md focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent resize-none"
-              placeholder="Payment due within 30 days"
+              placeholder={tInvoice('invoice.terms.placeholder') || 'Payment due within 30 days'}
             />
           </div>
         </div>
       </div>
 
       {/* Demo Data Button */}
-      <div className="bg-white rounded-lg shadow-sm p-6 space-y-3">
+      <div className="bg-white rounded-lg shadow-sm p-6">
         <button
           onClick={onLoadDemoData}
           className="w-full py-3 flex items-center justify-center gap-2 bg-slate-100 hover:bg-slate-200 text-slate-700 rounded-md font-medium transition-colors"
         >
           <RotateCcw className="h-4 w-4" />
-          Try Demo
+          {tInvoice('invoice.demo.button') || 'Try Demo'}
         </button>
-
-        {onApplyTemplate && (
-          <a
-            href="/templates"
-            className="w-full py-3 flex items-center justify-center gap-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md font-medium transition-colors"
-          >
-            <Copy className="h-4 w-4" />
-            Choose Template
-          </a>
-        )}
       </div>
     </div>
   );

--- a/src/components/invoice/InvoicePreview.tsx
+++ b/src/components/invoice/InvoicePreview.tsx
@@ -2,7 +2,7 @@
 
 import { Invoice, Totals } from "@/lib/types";
 import { exportPDFWithLogo, exportCSV } from "@/lib/pdf-export";
-import { useI18n } from "@/i18n/context";
+import { useI18n } from '@/i18n/context';
 
 interface InvoicePreviewProps {
   invoice: Invoice;
@@ -15,7 +15,7 @@ export default function InvoicePreview({
   totals,
   className,
 }: InvoicePreviewProps) {
-  const { tCommon, tInvoice } = useI18n();
+  const { tInvoice } = useI18n();
 
   const handleExportPDF = async () => {
     await exportPDFWithLogo(invoice, totals);
@@ -32,6 +32,12 @@ export default function InvoicePreview({
   return (
     <div className={className}>
       <div className="shadow-sm overflow-hidden">
+        {/* Preview Header */}
+        {/*<div className="px-6 py-4 bg-white flex gap-3">
+          <h2 className="text-lg font-medium text-slate-900">
+            Invoice Preview
+          </h2>
+        </div>*/}
         {/* Invoice Preview */}
         <div className="pb-6 drop-shadow-md">
           <div className="border p-6 bg-white">
@@ -39,14 +45,14 @@ export default function InvoicePreview({
             <div className="flex justify-between items-start mb-6">
               <div className="text-center">
                 <h1 className="text-2xl font-light text-slate-900 tracking-wide">
-                  {tInvoice("title")}
+                  {tInvoice('invoice.preview.title') || 'INVOICE'}
                 </h1>
               </div>
               {invoice.logoUrl && (
                 <div className="max-w-[120px] max-h-[60px]">
                   <img
                     src={invoice.logoUrl}
-                    alt="Company Logo"
+                    alt={tInvoice('invoice.preview.logoAlt') || 'Company Logo'}
                     className="max-w-full max-h-full object-contain"
                   />
                 </div>
@@ -57,15 +63,15 @@ export default function InvoicePreview({
             <div className="flex justify-between mb-6">
               <div className="text-sm text-slate-600">
                 <div>
-                  <span className="font-medium">{tInvoice("meta.invoiceNumber")}</span>{" "}
+                  <span className="font-medium">{tInvoice('invoice.preview.invoiceNumber') || 'Invoice #:'}</span>{" "}
                   {invoice.number || "---"}
                 </div>
                 <div>
-                  <span className="font-medium">{tInvoice("meta.date")}</span>{" "}
+                  <span className="font-medium">{tInvoice('invoice.preview.date') || 'Date:'}</span>{" "}
                   {invoice.date || "---"}
                 </div>
                 <div>
-                  <span className="font-medium">{tInvoice("meta.dueDate")}</span>{" "}
+                  <span className="font-medium">{tInvoice('invoice.preview.dueDate') || 'Due Date:'}</span>{" "}
                   {invoice.dueDate || "---"}
                 </div>
               </div>
@@ -75,7 +81,7 @@ export default function InvoicePreview({
             <div className="grid grid-cols-2 gap-6 mb-6">
               <div>
                 <h3 className="text-sm font-medium text-slate-500 mb-2">
-                  {tInvoice("from")}
+                  {tInvoice('invoice.preview.from') || 'From:'}
                 </h3>
                 <div className="text-sm text-slate-900">
                   {invoice.from.businessName || "---"}
@@ -92,7 +98,7 @@ export default function InvoicePreview({
                 </div>
               </div>
               <div>
-                <h3 className="text-sm font-medium text-slate-500 mb-2">{tInvoice("to")}</h3>
+                <h3 className="text-sm font-medium text-slate-500 mb-2">{tInvoice('invoice.preview.to') || 'To:'}</h3>
                 <div className="text-sm text-slate-900">
                   {invoice.to.clientName || "---"}
                   {invoice.to.company && <div>{invoice.to.company}</div>}
@@ -115,16 +121,16 @@ export default function InvoicePreview({
               <thead>
                 <tr className="border-b">
                   <th className="text-left text-sm font-medium text-slate-500 py-2">
-                    {tInvoice("table.description")}
+                    {tInvoice('invoice.preview.description') || 'Description'}
                   </th>
                   <th className="text-right text-sm font-medium text-slate-500 py-2">
-                    {tInvoice("table.qty")}
+                    {tInvoice('invoice.preview.qty') || 'Qty'}
                   </th>
                   <th className="text-right text-sm font-medium text-slate-500 py-2">
-                    {tInvoice("table.rate")}
+                    {tInvoice('invoice.preview.rate') || 'Rate'}
                   </th>
                   <th className="text-right text-sm font-medium text-slate-500 py-2">
-                    {tInvoice("table.amount")}
+                    {tInvoice('invoice.preview.amount') || 'Amount'}
                   </th>
                 </tr>
               </thead>
@@ -152,21 +158,21 @@ export default function InvoicePreview({
             <div className="flex justify-end">
               <div className="w-48 space-y-2">
                 <div className="flex justify-between text-sm">
-                  <span className="text-slate-600">{tInvoice("totals.subtotal")}</span>
+                  <span className="text-slate-600">{tInvoice('invoice.preview.subtotal') || 'Subtotal:'}</span>
                   <span className="font-mono text-slate-900">
                     ${totals.subtotal.toFixed(2)}
                   </span>
                 </div>
                 <div className="flex justify-between text-sm">
                   <span className="text-slate-600">
-                    {tInvoice("totals.tax", { rate: invoice.taxRate })}
+                    {tInvoice('invoice.preview.taxLabel') || 'Tax'} ({invoice.taxRate}%):
                   </span>
                   <span className="font-mono text-slate-900">
                     ${totals.taxAmount.toFixed(2)}
                   </span>
                 </div>
                 <div className="flex justify-between text-base font-medium border-t pt-2">
-                  <span className="text-slate-900">{tInvoice("totals.total")}</span>
+                  <span className="text-slate-900">{tInvoice('invoice.preview.total') || 'Total:'}</span>
                   <span className="font-mono text-slate-900">
                     ${totals.total.toFixed(2)}
                   </span>
@@ -180,7 +186,7 @@ export default function InvoicePreview({
                 {invoice.notes && (
                   <div>
                     <h3 className="text-sm font-medium text-slate-500 mb-1">
-                      {tInvoice("notes")}
+                      {tInvoice('invoice.preview.notesLabel') || 'Notes:'}
                     </h3>
                     <p className="text-sm text-slate-600">{invoice.notes}</p>
                   </div>
@@ -188,7 +194,7 @@ export default function InvoicePreview({
                 {invoice.terms && (
                   <div>
                     <h3 className="text-sm font-medium text-slate-500 mb-1">
-                      {tInvoice("terms")}
+                      {tInvoice('invoice.preview.termsLabel') || 'Terms:'}
                     </h3>
                     <p className="text-sm text-slate-600">{invoice.terms}</p>
                   </div>
@@ -204,19 +210,19 @@ export default function InvoicePreview({
             onClick={handleExportPDF}
             className="flex-1 bg-primary hover:bg-primary-hover text-white px-4 py-2 rounded-md font-medium transition-colors"
           >
-            {tCommon("actions.downloadPDF")}
+            {tInvoice('invoice.preview.downloadPdf') || 'Download PDF'}
           </button>
           <button
             onClick={handleExportCSV}
             className="flex-1 border border-slate-300 hover:bg-slate-100 text-slate-700 px-4 py-2 rounded-md font-medium transition-colors"
           >
-            {tCommon("actions.downloadCSV")}
+            {tInvoice('invoice.preview.downloadCsv') || 'Download CSV'}
           </button>
           <button
             onClick={handlePrint}
             className="flex-1 border border-slate-300 hover:bg-slate-100 text-slate-700 px-4 py-2 rounded-md font-medium transition-colors"
           >
-            {tCommon("actions.print")}
+            {tInvoice('invoice.preview.print') || 'Print'}
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary

修复切换语言后编辑表单和预览没有更新的问题。

## Root Cause

在之前的 rebase 过程中，InvoiceForm 和 InvoicePreview 组件被意外恢复到了没有 i18n 的版本，导致 `useI18n` hook 和 `tInvoice` 翻译调用丢失。

## Changes

- 恢复 InvoiceForm 的 `useI18n` hook
- 恢复所有标签和占位符的 `tInvoice` 翻译调用
- 恢复 InvoicePreview 的 i18n 支持

## Testing

语言切换后，编辑表单和预览应立即更新为对应语言。

## Related

- Follow-up to #8