### PR TITLE
fix: 修复模板缩略图高度失控问题

### DIFF
--- a/src/components/templates/TemplateCard.tsx
+++ b/src/components/templates/TemplateCard.tsx
@@ -37,7 +37,7 @@ export default function TemplateCard({
         <p className="mt-1 text-sm text-slate-500 line-clamp-2">{template.description}</p>
       </div>
 
-      <div className="border-t border-slate-200 p-2 min-h-[120px]">
+      <div className="border-t border-slate-200 p-2">
         <TemplateThumbnail
           themeColor={template.themeColor}
           textFont={template.textFont}

--- a/src/components/templates/TemplateThumbnail.tsx
+++ b/src/components/templates/TemplateThumbnail.tsx
@@ -21,10 +21,10 @@ const TemplateThumbnail: React.FC<TemplateThumbnailProps> = ({
   const numberFontClass = numberFont === 'sans' ? 'font-sans' : numberFont === 'serif' ? 'font-serif' : 'font-mono';
 
   return (
-    <div className={`relative bg-white border rounded-lg shadow-sm overflow-hidden w-full h-64 flex items-center justify-center ${className}`}>
+    <div className={`relative bg-white border rounded-lg shadow-sm overflow-hidden w-full aspect-[4/3] flex items-center justify-center scale-95 ${className}`}>
       {/* 发票主体容器 */}
       <div
-        className="absolute inset-4 border rounded p-3"
+        className="absolute inset-3 border rounded p-2"
         style={{ borderColor: themeColor }}
       >
         {/* 标题行 */}


### PR DESCRIPTION
## Summary

修复模板页面中模板缩略图组件高度超出容器的问题。

**问题根因**：
- `TemplateThumbnail` 使用固定高度 `h-64`（256px）
- `TemplateCard` 设置了 `min-h-[120px]` 限制，但内容高度远超此值
- 两者结合导致缩略图高度超出容器，内容溢出

**修复方案**：
- `TemplateThumbnail` 使用 `aspect-[4/3]` 替代固定高度，根据宽度自动计算高度
- 添加 `scale-95` 让缩略图稍微缩小，确保完全适配容器
- 移除 `TemplateCard` 的 `min-h-[120px]` 限制

## Changes

- `src/components/templates/TemplateThumbnail.tsx`: 使用 `aspect-[4/3]` 替代 `h-64`，添加 `scale-95`
- `src/components/templates/TemplateCard.tsx`: 移除 `min-h-[120px]` 限制

## Testing

- [x] 开发服务器启动正常
- [x] 模板页面渲染正常
- [ ] 视觉验证（建议在浏览器中打开 `/templates` 页面确认）

## Related Issues

Fixes #17

## Checklist
- [x] Code follows project guidelines (`CLAUDE.md`)
- [x] Self-review completed
- [x] No console.log or debugging statements
- [ ] Documentation updated (if applicable)
- [x] No hardcoded secrets or credentials
- [x] Commit messages follow conventional format